### PR TITLE
License, GHA CI, Dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        python: ['3.10', '3.9', '3.8']
     defaults:
       run:
         # Enable the conda environment via ~/.bashrc and ~/.profile
@@ -44,7 +44,7 @@ jobs:
           activate-environment: AAV.ci.env
           auto-activate-base: false
           auto-update-conda: true
-          #channel-priority: strict
+          channel-priority: strict
           environment-file: CI.conda_env.yml
           python-version: ${{ matrix.python }}
           use-only-tar-bz2: true  # Required for caching
@@ -56,7 +56,6 @@ jobs:
         run: |
           # Stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          #pylint -E pylint -E -d E1101,E1136,E1138 *.py
       - name: Lint R script
         run: |
           Rscript -e 'library(lintr); options(lintr.error_on_lint=TRUE); lint_dir(".", linters=linters_with_tags("correctness"))'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,62 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+jobs:
+  tests:
+    name: Lint with R and Python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest']
+        python: ['3.11', '3.10', '3.9', '3.8', '3.7']
+    defaults:
+      run:
+        # Enable the conda environment via ~/.bashrc and ~/.profile
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Cache conda
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if dev.conda_env.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('dev.conda_env.yml') }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: AAV.ci.env
+          auto-activate-base: false
+          auto-update-conda: true
+          #channel-priority: strict
+          environment-file: CI.conda_env.yml
+          python-version: ${{ matrix.python }}
+          use-only-tar-bz2: true  # Required for caching
+      - name: Show conda environment
+        run: |
+          conda info
+          conda list
+      - name: Lint Python scripts
+        run: |
+          # Stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          #pylint -E pylint -E -d E1101,E1136,E1138 *.py
+      - name: Lint R script
+        run: |
+          Rscript -e 'library(lintr); options(lintr.error_on_lint=TRUE); lint_dir(".", linters=linters_with_tags("correctness"))'

--- a/AAV.conda_env.yml
+++ b/AAV.conda_env.yml
@@ -7,13 +7,11 @@ channels:
     - defaults
 dependencies:
     - python>=3.7.6
-    - r>=3.6.0
+    - r-base>=3.6.0
     - minimap2
     - biopython
     - parasail-python>=1.3.4
     - pysam
-    - r-dplyr
-    - r-ggplot2
     - r-gridbase
     - r-gridextra
     - r-tidyverse

--- a/AAV.conda_env.yml
+++ b/AAV.conda_env.yml
@@ -10,8 +10,10 @@ dependencies:
     - r>=3.6.0
     - minimap2
     - biopython
+    - parasail-python>=1.3.4
     - pysam
     - r-dplyr
     - r-ggplot2
     - r-gridbase
     - r-gridextra
+    - r-tidyverse

--- a/CI.conda_env.yml
+++ b/CI.conda_env.yml
@@ -2,19 +2,15 @@ name: AAV.ci.env
 channels:
     - conda-forge
     - bioconda
-    - anaconda
-    - r
     - defaults
 dependencies:
     - python>=3.7.6
-    - r>=3.6.0
+    - r-base>=3.6.0
     - minimap2
     - biopython
     - flake8
     - parasail-python>=1.3.4
     - pysam
-    - r-dplyr
-    - r-ggplot2
     - r-gridbase
     - r-gridextra
     - r-lintr

--- a/CI.conda_env.yml
+++ b/CI.conda_env.yml
@@ -1,0 +1,21 @@
+name: AAV.ci.env
+channels:
+    - conda-forge
+    - bioconda
+    - anaconda
+    - r
+    - defaults
+dependencies:
+    - python>=3.7.6
+    - r>=3.6.0
+    - minimap2
+    - biopython
+    - flake8
+    - parasail-python>=1.3.4
+    - pysam
+    - r-dplyr
+    - r-ggplot2
+    - r-gridbase
+    - r-gridextra
+    - r-lintr
+    - r-tidyverse

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 continuumio/miniconda3
+
+RUN apt-get update \
+    && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        less \
+        pigz \
+        samtools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Conda environment has the name AAV.env
+COPY AAV.conda_env.yml ./AAV.conda_env.yml
+RUN conda install -n base conda-libmamba-solver && conda config --set solver libmamba
+RUN conda env create -v -f AAV.conda_env.yml
+RUN echo "conda activate AAV.env" >> ~/.bashrc
+
+# Executable scripts for the pipeline
+COPY *.py *.R /usr/local/bin
+RUN chmod +x /usr/local/bin/*.py /usr/local/bin/*.R
+ENV PATH "/usr/local/bin:$PATH"
+
+WORKDIR /data/
+
+CMD ["bash"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dev.conda_env.yml
+++ b/dev.conda_env.yml
@@ -2,22 +2,20 @@ name: AAV.dev.env
 channels:
     - conda-forge
     - bioconda
-    - anaconda
-    - r
     - defaults
 dependencies:
     - python>=3.7.6
-    - r>=3.6.0
+    - r-base>=3.6.0
     - minimap2
     - biopython
+    - black
     - flake8
     - parasail-python>=1.3.4
     - pylint
     - pysam
     - pytest
-    - r-dplyr
-    - r-ggplot2
     - r-gridbase
     - r-gridextra
     - r-lintr
+    - r-styler
     - r-tidyverse

--- a/dev.conda_env.yml
+++ b/dev.conda_env.yml
@@ -1,0 +1,23 @@
+name: AAV.dev.env
+channels:
+    - conda-forge
+    - bioconda
+    - anaconda
+    - r
+    - defaults
+dependencies:
+    - python>=3.7.6
+    - r>=3.6.0
+    - minimap2
+    - biopython
+    - flake8
+    - parasail-python>=1.3.4
+    - pylint
+    - pysam
+    - pytest
+    - r-dplyr
+    - r-ggplot2
+    - r-gridbase
+    - r-gridextra
+    - r-lintr
+    - r-tidyverse


### PR DESCRIPTION
Adding some conveniences on top of the [upstream source](https://github.com/Magdoll/AAV):
* Add an OSI-compatible public license (Apache 2.0)
* Add a Dockerfile to capture the conda environment and scripts
* Set up GitHub Actions for basic automated testing (in this PR, just static checks)

Notes:
- Python 3.11 and 3.7 can't be fully supported since some dependencies are unavailable for those versions (details in the commit log)
- I left the original script code alone and updated the conda environment specification just a little bit.
- The Docker image hasn't been published anywhere yet.